### PR TITLE
feature request: Support build a project as monorepo-like

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = class Plugin {
     } catch (e) {
       this.serverless.cli.consoleLog(
         `Go Plugin: ${chalk.yellow(
-          `Error compiling "${name}" function (cwd: ${config.baseDir}): ${e.message}`
+          `Error compiling "${name}" function (cwd: ${cwd}): ${e.message}`
         )}`
       );
       process.exit(1);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const chalk = require("chalk");
 const path = require("path");
 
 const ConfigDefaults = {
+  monorepo: false,
   baseDir: ".",
   binDir: ".bin",
   cgo: 0,
@@ -102,13 +103,25 @@ module.exports = class Plugin {
 
     const absHandler = path.resolve(config.baseDir);
     const absBin = path.resolve(config.binDir);
-    const compileBinPath = path.join(path.relative(absHandler, absBin), name); // binPath is based on cwd no baseDir
+    let compileBinPath = path.join(path.relative(absHandler, absBin), name); // binPath is based on cwd no baseDir
+    let cwd = config.baseDir;
+    let handler = func.handler;
+    if (config.monorepo) {
+      if (func.handler.endsWith(".go")) {
+        cwd = path.relative(absHandler, path.dirname(func.handler));
+        handler = path.basename(handler);
+      } else {
+        cwd = path.relative(absHandler, func.handler);
+        handler = ".";
+      }
+      compileBinPath = path.relative(cwd, compileBinPath);
+    }
     try {
       const [env, command] = parseCommand(
-        `${config.cmd} -o ${compileBinPath} ${func.handler}`
+        `${config.cmd} -o ${compileBinPath} ${handler}`
       );
       await exec(command, {
-        cwd: config.baseDir,
+        cwd: cwd,
         env: Object.assign(
           {},
           process.env,

--- a/index.test.js
+++ b/index.test.js
@@ -284,6 +284,54 @@ describe("Go Plugin", () => {
       );
       expect(execStub.firstCall.args[1].cwd).to.equal(".");
     });
+
+    it("compiles Go function w/ monorepo", async () => {
+      // given
+      const config = merge(
+        {
+          service: {
+            custom: {
+              go: {
+                monorepo: true,
+              },
+            },
+            functions: {
+              testFunc1: {
+                name: "testFunc1",
+                runtime: "go1.x",
+                handler: "functions/func1",
+              },
+              testFunc2: {
+                name: "testFunc2",
+                runtime: "go1.x",
+                handler: "functions/func2/main.go",
+              },
+            },
+          },
+        },
+        serverlessStub
+      );
+      const plugin = new Plugin(config);
+
+      // when
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
+
+      // then
+      expect(config.service.functions.testFunc1.handler).to.equal(
+        `.bin/testFunc1`
+      );
+      expect(execStub).to.have.been.calledWith(
+        `go build -ldflags="-s -w" -o ../../.bin/testFunc1 .`
+      );
+      expect(execStub.firstCall.args[1].cwd).to.equal("functions/func1");
+      expect(config.service.functions.testFunc2.handler).to.equal(
+        `.bin/testFunc2`
+      );
+      expect(execStub).to.have.been.calledWith(
+        `go build -ldflags="-s -w" -o ../../.bin/testFunc2 main.go`
+      );
+      expect(execStub.secondCall.args[1].cwd).to.equal("functions/func2");
+    });
   });
 
   describe(`serverless go build`, () => {


### PR DESCRIPTION
In my project I needed to support a monorepo-like structure that there is go.mod in each folder.

For example it has below structure:
```
└── serverless-project
    ├── node_modules
    ├── functions
    │   ├── func1
    │   │   ├── go.mod
    │   │   ├── go.sum
    │   │   └── main.go
    │   ├── func2
    │   │   ├── fuga
    │   │   │   └── fuga.go
    │   │   ├── go.mod
    │   │   ├── go.sum
    │   │   └── main.go
    └── serverless.yaml
```

So I added the monorepo flag into config and I improve this plugin that it specified function directory to cwd on build command when enable monorepo flag. Maybe the test code is easy to understand in detail.