### PR TITLE
feat: support snippet for baseDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ custom:
     cmd: GOOS=linux go build -ldflags="-s -w"' # compile command
 ```
 
+**baseDir** accept the following macros:
+
+| Name           | Description                                     | Example                                                                                |
+|----------------|-------------------------------------------------|----------------------------------------------------------------------------------------|
+| `{{handlerDir}}` | Will be resolved as the dir path of the handler | handler is `fns/hello/main.go` or `fns/hello` , then `{{handlerDir}}` will be fns/hello/ |
+
 ## How does it work?
 
 The plugin compiles every Go function defined in `serverless.yaml` into `.bin` directory. After that it internally changes `handler` so that the Serverless Framework will deploy the compiled file not the source file. The plugin compiles a function only if `runtime` (either on function or provider level) is set to Go (`go1.x`).

--- a/index.test.js
+++ b/index.test.js
@@ -142,6 +142,72 @@ describe("Go Plugin", () => {
       expect(execStub.firstCall.args[1].cwd).to.equal("gopath");
     });
 
+    it("compiles Go function w/ base dir macro", async () => {
+      // given
+      const config = merge(
+        {
+          service: {
+            custom: {
+              go: {
+                baseDir: "{{handlerDir}}",
+              },
+            },
+            functions: {
+              testFunc1: {
+                name: "testFunc1",
+                runtime: "go1.x",
+                handler: "functions/func1/main.go",
+              },
+            },
+          },
+        },
+        serverlessStub
+      );
+      const plugin = new Plugin(config);
+
+      // when
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
+
+      // then
+      expect(execStub).to.have.been.calledOnceWith(
+        `go build -ldflags="-s -w" -o ../../.bin/testFunc1 main.go`
+      );
+      expect(execStub.firstCall.args[1].cwd).to.equal("functions/func1/");
+    });
+
+    it("compiles Go function (package) w/ base dir macro", async () => {
+      // given
+      const config = merge(
+        {
+          service: {
+            custom: {
+              go: {
+                baseDir: "{{handlerDir}}",
+              },
+            },
+            functions: {
+              testFunc1: {
+                name: "testFunc1",
+                runtime: "go1.x",
+                handler: "functions/func1",
+              },
+            },
+          },
+        },
+        serverlessStub
+      );
+      const plugin = new Plugin(config);
+
+      // when
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
+
+      // then
+      expect(execStub).to.have.been.calledOnceWith(
+        `go build -ldflags="-s -w" -o ../../.bin/testFunc1 .`
+      );
+      expect(execStub.firstCall.args[1].cwd).to.equal("functions/func1/");
+    });
+
     it("compiles Go function w/ global runtime defined", async () => {
       // given
       const config = merge(


### PR DESCRIPTION
Support path resolver for baseDir, so that we can use handler's dirname as baseDir.