### PR TITLE
support macOS on M1 chip: add GOARCH amd64 to build cmd

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const ConfigDefaults = {
   baseDir: ".",
   binDir: ".bin",
   cgo: 0,
-  cmd: 'GOOS=linux go build -ldflags="-s -w"',
+  cmd: 'GOOS=linux GOARCH=amd64 go build -ldflags="-s -w"',
   monorepo: false,
 };
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = class Plugin {
     };
   }
 
-  async compileFunction() {
+  async compileFunction () {
     const name = this.options.function;
     const func = this.serverless.service.functions[this.options.function];
 
@@ -74,7 +74,7 @@ module.exports = class Plugin {
     );
   }
 
-  async compileFunctions() {
+  async compileFunctions () {
     if (this.isInvoking) {
       return;
     }
@@ -97,16 +97,16 @@ module.exports = class Plugin {
     );
   }
 
-  compileFunctionAndIgnorePackage() {
+  compileFunctionAndIgnorePackage () {
     this.isInvoking = true;
     return this.compileFunction();
   }
 
-  async compile(name, func) {
+  async compile (name, func) {
     const config = this.getConfig();
 
     const runtime = func.runtime || this.serverless.service.provider.runtime;
-    if (runtime !== GoRuntime || runtime !== Arm64Runtime) {
+    if (runtime !== GoRuntime && runtime !== Arm64Runtime) {
       return;
     }
 
@@ -176,7 +176,7 @@ module.exports = class Plugin {
 };
 
 const envSetterRegex = /^(\w+)=('(.*)'|"(.*)"|(.*))/;
-function parseCommand(cmd) {
+function parseCommand (cmd) {
   const args = cmd.split(" ");
   const envSetters = {};
   let command = "";

--- a/index.js
+++ b/index.js
@@ -15,7 +15,16 @@ const ConfigDefaults = {
   monorepo: false,
 };
 
+const Arm64ConfigDefaults = {
+  baseDir: ".",
+  binDir: ".bin",
+  cgo: 0,
+  cmd: 'GOOS=linux GOARCH=arm go build -ldflags="-s -w"',
+  monorepo: false,
+};
+
 const GoRuntime = "go1.x";
+const Arm64Runtime = "provided.al2";
 
 module.exports = class Plugin {
   constructor(serverless, options) {
@@ -97,7 +106,7 @@ module.exports = class Plugin {
     const config = this.getConfig();
 
     const runtime = func.runtime || this.serverless.service.provider.runtime;
-    if (runtime !== GoRuntime) {
+    if (runtime !== GoRuntime || runtime !== Arm64Runtime) {
       return;
     }
 
@@ -156,8 +165,9 @@ module.exports = class Plugin {
     this.serverless.service.functions[name].package = packageConfig;
   }
 
-  getConfig() {
-    let config = ConfigDefaults;
+  getConfig () {
+    let isArm64 = this.serverless.architecture === 'arm64'
+    let config = isArm64 ? Arm64ConfigDefaults : ConfigDefaults;
     if (this.serverless.service.custom && this.serverless.service.custom.go) {
       config = merge(config, this.serverless.service.custom.go);
     }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ module.exports = class Plugin {
   }
 
   getConfig () {
-    let isArm64 = this.serverless.architecture === 'arm64'
+    let isArm64 = this.serverless.service.provider.architecture === 'arm64'
     let config = isArm64 ? Arm64ConfigDefaults : ConfigDefaults;
     if (this.serverless.service.custom && this.serverless.service.custom.go) {
       config = merge(config, this.serverless.service.custom.go);


### PR DESCRIPTION
Default GOARCH on macOS M1 chip is not amd64, it causes built binary can not be executed on lambda, default GOARCH=amd64 should be added to the build cmd.