### PR TITLE
Allow to specify multiple runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ custom:
     cgo: 0 # CGO_ENABLED flag
     cmd: GOOS=linux go build -ldflags="-s -w"' # compile command
     monorepo: false # if enabled, builds function every directory (useful for monorepo where go.mod is managed by each function
+    supportedRuntimes: ["go1.x"] # the plugin compiles a function only if runtime is declared here (either on function or provider level) 
+    buildAsBootstrap: false # if enabled, builds and archive function with only single "bootstrap" binary (useful for runtimes like provided.al2)
 ```
 
 ## How does it work?
 
-The plugin compiles every Go function defined in `serverless.yaml` into `.bin` directory. After that it internally changes `handler` so that the Serverless Framework will deploy the compiled file not the source file. The plugin compiles a function only if `runtime` (either on function or provider level) is set to Go (`go1.x`).
+The plugin compiles every Go function defined in `serverless.yaml` into `.bin` directory. After that it internally changes `handler` so that the Serverless Framework will deploy the compiled file not the source file.
 
 For every matched function it also overrides `package` parameter to
 
@@ -69,3 +71,15 @@ exclude:
 include:
   - `<path to the compiled file and any files that you defined to be included>`
 ```
+
+## How to run Golang Lambda on ARM?
+
+1. Add `provided.al2` to `supportedRuntimes` and enable `buildAsBootstrap` in plugin config
+2. Append `GOARCH=arm64` to your compile command (`cmd` line)
+3. Change architecture in global config:
+```yaml
+provider:
+    architecture: arm64
+```   
+
+**Warning!** First deploy may result in small downtime (~few seconds) of lambda, use some deployment strategy like canary for safer rollout.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ custom:
     cmd: GOOS=linux go build -ldflags="-s -w"' # compile command
     monorepo: false # if enabled, builds function every directory (useful for monorepo where go.mod is managed by each function
     supportedRuntimes: ["go1.x"] # the plugin compiles a function only if runtime is declared here (either on function or provider level) 
-    buildAsBootstrap: false # if enabled, builds and archive function with only single "bootstrap" binary (useful for runtimes like provided.al2)
+    buildProvidedRuntimeAsBootstrap: false # if enabled, builds and archive function with only single "bootstrap" binary (useful for runtimes like provided.al2)
 ```
 
 ## How does it work?
@@ -74,12 +74,13 @@ include:
 
 ## How to run Golang Lambda on ARM?
 
-1. Add `provided.al2` to `supportedRuntimes` and enable `buildAsBootstrap` in plugin config
+1. Add `provided.al2` to `supportedRuntimes` and enable `buildProvidedRuntimeAsBootstrap` in plugin config
 2. Append `GOARCH=arm64` to your compile command (`cmd` line)
-3. Change architecture in global config:
+3. Change architecture and runtime in global config:
 ```yaml
 provider:
     architecture: arm64
+    runtime: provided.al2
 ```   
 
 **Warning!** First deploy may result in small downtime (~few seconds) of lambda, use some deployment strategy like canary for safer rollout.

--- a/index.test.js
+++ b/index.test.js
@@ -398,14 +398,20 @@ describe("Go Plugin", () => {
           service: {
             custom: {
               go: {
-                buildAsBootstrap: true,
+                supportedRuntimes: ["go1.x", "provided.al2"],
+                buildProvidedRuntimeAsBootstrap: true,
               },
             },
             functions: {
               testFunc1: {
                 name: "testFunc1",
-                runtime: "go1.x",
+                runtime: "provided.al2",
                 handler: "functions/func1",
+              },
+              testFunc2: {
+                name: "testFunc2",
+                runtime: "go1.x",
+                handler: "functions/func1/main.go",
               },
             },
           },
@@ -421,6 +427,12 @@ describe("Go Plugin", () => {
       expect(config.service.functions.testFunc1.package).to.deep.equal({
         individually: true,
         artifact: ".bin/testFunc1.zip",
+      });
+
+      expect(config.service.functions.testFunc2.package).to.deep.equal({
+        individually: true,
+        exclude: ["./**"],
+        include: [".bin/testFunc2"],
       });
     });
   });

--- a/index.test.js
+++ b/index.test.js
@@ -10,11 +10,23 @@ describe("Go Plugin", () => {
   let sandbox;
   let execStub;
   let Plugin;
+  let readFileSyncStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     execStub = sandbox.stub().resolves({ stdin: null, stdout: null });
+    readFileSyncStub = sinon
+      .stub()
+      .withArgs(".bin/testFunc1")
+      .returns("fake binary content");
+    const admZipInstance = {
+      addFile: sinon.stub(),
+      writeZip: sinon.stub(),
+    };
+    const admZipStub = sinon.stub().callsFake(() => admZipInstance);
     Plugin = proxyquire("./index.js", {
+      fs: { readFileSync: readFileSyncStub },
+      "adm-zip": admZipStub,
       util: {
         promisify: () => execStub,
       },
@@ -72,6 +84,52 @@ describe("Go Plugin", () => {
       );
       expect(execStub).to.have.been.calledWith(
         `go build -ldflags="-s -w" -o .bin/testFunc3 functions/func3`
+      );
+    });
+
+    it("compiles function with supported runtime", async () => {
+      // given
+      const config = merge(
+        {
+          service: {
+            custom: {
+              go: {
+                supportedRuntimes: ["go1.x", "provided.al2"],
+              },
+            },
+            functions: {
+              testFunc1: {
+                name: "testFunc1",
+                runtime: "provided.al2",
+                handler: "functions/func1/main.go",
+              },
+              testFunc2: {
+                name: "testFunc2",
+                runtime: "go1.x",
+                handler: "functions/func2/main.go",
+              },
+            },
+          },
+        },
+        serverlessStub
+      );
+      const plugin = new Plugin(config);
+
+      // when
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
+
+      // then
+      expect(config.service.functions.testFunc2.handler).to.equal(
+        `.bin/testFunc2`
+      );
+      expect(execStub).to.have.been.calledWith(
+        `go build -ldflags="-s -w" -o .bin/testFunc2 functions/func2/main.go`
+      );
+      expect(config.service.functions.testFunc1.handler).to.equal(
+        `.bin/testFunc1`
+      );
+      expect(execStub).to.have.been.calledWith(
+        `go build -ldflags="-s -w" -o .bin/testFunc1 functions/func1/main.go`
       );
     });
 
@@ -331,6 +389,39 @@ describe("Go Plugin", () => {
         `go build -ldflags="-s -w" -o ../../.bin/testFunc2 main.go`
       );
       expect(execStub.secondCall.args[1].cwd).to.equal("functions/func2");
+    });
+
+    it("compiles bootstrap", async () => {
+      // given
+      const config = merge(
+        {
+          service: {
+            custom: {
+              go: {
+                buildAsBootstrap: true,
+              },
+            },
+            functions: {
+              testFunc1: {
+                name: "testFunc1",
+                runtime: "go1.x",
+                handler: "functions/func1",
+              },
+            },
+          },
+        },
+        serverlessStub
+      );
+      const plugin = new Plugin(config);
+
+      // when
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
+
+      // then
+      expect(config.service.functions.testFunc1.package).to.deep.equal({
+        individually: true,
+        artifact: ".bin/testFunc1.zip",
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,6 +280,11 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
+    },
     "agent-base": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/mthenw/serverless-go-plugin#readme",
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "chalk": "^2.4.2",
     "lodash.merge": "^4.6.2",
     "p-map": "^3.0.0",


### PR DESCRIPTION
As AWS supports ARM architecture for 20% billing saving `serverless-go-plugin` should allow to compile single `bootstrap` file for `provided.al2` runtime.