### PR TITLE
Update conditional block for package inclusion in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,8 @@ module.exports = class Plugin {
     this.serverless.service.functions[name].handler = binPath;
     const packageConfig = this.generatePackageConfig(runtime, config, binPath);
 
-    if (this.serverless.service.functions[name].package) {
+    if (this.serverless.service.functions[name].package
+        && this.serverless.service.functions[name].package.include) {
       packageConfig.include = packageConfig.include.concat(
         this.serverless.service.functions[name].package.include
       );


### PR DESCRIPTION
Fixes #39 exception on undefined.concat.

This change ensures the inclusion of a package only when it exists and has the 'include' property. Before, the logic would throw an error when the function's package property exists but doesn't have the 'include' property.