### PR TITLE
feat(runtime): add provided.al2023 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const ConfigDefaults = {
 };
 
 // amazonProvidedRuntimes contains Amazon Linux runtimes. Update this array after each new version release.
-const amazonProvidedRuntimes = ["provided.al2"];
+const amazonProvidedRuntimes = ["provided.al2", "provided.al2023"];
 
 module.exports = class Plugin {
   constructor(serverless, options) {
@@ -175,7 +175,7 @@ module.exports = class Plugin {
     }
     return {
       individually: true,
-      exclude: [`./**`],
+      exclude: ["./**"],
       include: [binPath],
     };
   }


### PR DESCRIPTION
Recently AWS added [new runtime](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/) `provided.al2023`, this PR add this into `amazonProvidedRuntimes` array.

I am thinking if `generatePackageConfig` should just ignore `amazonProvidedRuntimes` check and always generate a bootstrap entrypoint if `config.buildProvidedRuntimeAsBootstrap` is set to `true`. This check seems a bit redundant in my opinion as user most probably wants bootstrap entrypoint if it is set to `true` explicitly anyway. 🤔 