### PR TITLE
Fix sample config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ custom:
     baseDir: . # folder where go.mod file lives, if set `handler` property should be set relatively to that folder
     binDir: .bin # target folder for binary files
     cgo: 0 # CGO_ENABLED flag
-    cmd: GOOS=linux go build -ldflags="-s -w"' # compile command
+    cmd: 'GOOS=linux go build -ldflags="-s -w"' # compile command
     monorepo: false # if enabled, builds function every directory (useful for monorepo where go.mod is managed by each function
     supportedRuntimes: ["go1.x"] # the plugin compiles a function only if runtime is declared here (either on function or provider level) 
     buildProvidedRuntimeAsBootstrap: false # if enabled, builds and archive function with only single "bootstrap" binary (useful for runtimes like provided.al2)


### PR DESCRIPTION
Added missing `'` to the README default values.