### PR TITLE
fix: prevent container functions from being processed as Go handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ module.exports = class Plugin {
     let compileBinPath = path.join(path.relative(absHandler, absBin), name); // binPath is based on cwd no baseDir
     let cwd = config.baseDir;
     let handler = func.handler;
+    if (handler == null) return;
     if (config.monorepo) {
       if (func.handler.endsWith(".go")) {
         cwd = path.relative(absHandler, path.dirname(func.handler));

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ module.exports = class Plugin {
     let compileBinPath = path.join(path.relative(absHandler, absBin), name); // binPath is based on cwd no baseDir
     let cwd = config.baseDir;
     let handler = func.handler;
+    // Exclude container functions
     if (handler == null) return;
     if (config.monorepo) {
       if (func.handler.endsWith(".go")) {


### PR DESCRIPTION
related to #54 

### Changes

Fixed an issue where containerized functions were incorrectly treated as Go handlers. This fix ensures that container functions are properly identified and no longer processed as Go handlers.

### Issue Details

During deployment or packaging, containerized functions were sometimes mistakenly treated as Go handlers. This resulted in handlers being undefined, causing the go build command to fail and generate errors.

### Testing

In the test environment, the go build command is not actually executed, so the error does not reproduce. However, in the production environment, the go build command fails and generates errors.